### PR TITLE
Fix #17; support scanning for files that have URI-encoded paths

### DIFF
--- a/scripts/classes/Scenery.js
+++ b/scripts/classes/Scenery.js
@@ -133,6 +133,8 @@ export default class Scenery extends FormApplication {
     const defName = path.split('/').pop().split('.').slice(0, -1).join('.');
     // For each file in directory...
     const variations = fp.files
+      // FilePicker returns encoded paths, decode them
+      .map(decodeURI)
       // Remove default file
       .filter((f) => f !== path)
       // Find only files which are derivatives of default


### PR DESCRIPTION
The FileBrowser API returns paths that are URI-encoded. Map the results array using decodeURI to bring the special characters back. Tested with Foundry 11.315.