### PR TITLE
chore: migrate to trunk-based development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure git to use HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: pnpm run lint
 
       - name: Format check
+        if: github.event_name == 'push'
         run: pnpm run format:check
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    branches: [master]
   pull_request:
-    branches: [develop]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/format-weblate.yml
+++ b/.github/workflows/format-weblate.yml
@@ -1,0 +1,48 @@
+name: Auto-format
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'languages/**'
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Format language files
+        run: pnpm exec prettier --write "languages/**/*.json"
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add languages/
+          git commit -m "style: format translation files"
+          git push

--- a/.github/workflows/format-weblate.yml
+++ b/.github/workflows/format-weblate.yml
@@ -2,7 +2,7 @@ name: Auto-format
 
 on:
   push:
-    branches: [develop]
+    branches: [master]
     paths:
       - 'languages/**'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,23 @@ jobs:
           artifacts: './module.json, ./module.zip'
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}
+
+      - name: Publish to Foundry VTT
+        if: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          curl -sf -X POST "https://foundryvtt.com/_api/packages/release_version/" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}" \
+            -d "{
+              \"id\": \"scenery\",
+              \"release\": {
+                \"version\": \"${VERSION}\",
+                \"manifest\": \"https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/module.json\",
+                \"notes\": \"https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\",
+                \"compatibility\": {
+                  \"minimum\": \"13\",
+                  \"verified\": \"13\"
+                }
+              }
+            }"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,12 +60,14 @@ jobs:
           body: ${{ github.event.release.body }}
 
       - name: Publish to Foundry VTT
-        if: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}
+        env:
+          FOUNDRY_PACKAGE_TOKEN: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}
+        if: ${{ env.FOUNDRY_PACKAGE_TOKEN != '' }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           curl -sf -X POST "https://foundryvtt.com/_api/packages/release_version/" \
             -H "Content-Type: application/json" \
-            -H "Authorization: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}" \
+            -H "Authorization: $FOUNDRY_PACKAGE_TOKEN" \
             -d "{
               \"id\": \"scenery\",
               \"release\": {

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - develop
+      - master
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/SETUP-REPOS.md
+++ b/SETUP-REPOS.md
@@ -1,0 +1,149 @@
+# Repository Setup Guide
+
+Setup-Schritte für GitHub und GitLab nach dem v13-Release. Diese Datei ist nicht
+Teil des Repositories — nach Abarbeitung löschen.
+
+---
+
+## GitHub
+
+### Repository Settings
+
+1. **Settings > General**
+   - Description:
+     `Manage background image variations per scene with separate GM/Player views, automatic scene element capture, smart map scanning, and instant switching.`
+   - Website: Release-URL oder leer lassen
+   - Topics: `foundryvtt`, `foundryvtt-module`, `foundry-vtt`, `scenery`
+
+2. **Settings > General > Pull Requests**
+   - [x] Allow squash merging (empfohlen als Default)
+   - [ ] Allow merge commits — optional deaktivieren
+   - [x] Automatically delete head branches
+
+3. **Settings > Branches > Branch protection rules**
+   - Branch: `master`
+   - [x] Require a pull request before merging
+   - [x] Require status checks to pass before merging
+     - Required checks: `validate` (aus `ci.yml`)
+   - [x] Require branches to be up to date before merging
+   - [ ] Include administrators — optional, wenn du dir selbst Bypasses erlauben
+         willst
+
+4. **Settings > Environments** (optional)
+   - Environment `release` erstellen
+   - Deployment protection: nur Tags `v*`
+
+### Labels prüfen
+
+Der Release Drafter nutzt Labels zum Kategorisieren. Folgende Labels sollten
+existieren (werden teils automatisch vom Autolabeler erstellt):
+
+- `feat` / `feature` / `enhancement`
+- `fix` / `bugfix` / `bug`
+- `refactor`
+- `docs`
+- `perf`
+- `security`
+- `build` / `ci` / `chore`
+- `test`
+- `style`
+- `major` / `minor` / `patch` (für Version Resolver)
+- `breaking`
+
+### Secrets
+
+Keine zusätzlichen Secrets nötig — `GITHUB_TOKEN` wird automatisch
+bereitgestellt.
+
+### Actions prüfen
+
+- **Settings > Actions > General**
+  - [x] Allow all actions and reusable workflows (oder auf `actions/*`,
+        `pnpm/*`, `ncipollo/*`, `release-drafter/*` beschränken)
+  - Workflow permissions: Read and write
+
+### Funding
+
+Bereits konfiguriert in `.github/FUNDING.yml`:
+
+- Ko-fi: `nerdybynature`
+- Patreon: `NerdyByNatureDev`
+
+Prüfen unter **Settings > General > Sponsorship** ob der "Sponsor" Button
+sichtbar ist.
+
+---
+
+## GitLab (Mirror)
+
+### Repository erstellen
+
+1. Neues Projekt auf GitLab erstellen (z.B. `foundryvtt-scenery`)
+2. **Settings > Repository > Mirroring repositories**
+   - Git repository URL: `https://github.com/marcstraube/foundryvtt-scenery.git`
+   - Mirror direction: **Pull** (GitLab zieht von GitHub)
+   - Authentication: Personal Access Token von GitHub mit `repo` Scope
+   - [x] Mirror only protected branches — deaktivieren, damit alle Branches +
+         Tags kommen
+   - Update interval: Automatisch (alle 5 Minuten)
+
+   Alternativ: Push-Mirror von GitHub nach GitLab einrichten (GitHub Actions).
+
+### CI/CD Variables
+
+Unter **Settings > CI/CD > Variables** anlegen:
+
+| Variable            | Value                            | Protected | Masked |
+| ------------------- | -------------------------------- | --------- | ------ |
+| `GITHUB_REPOSITORY` | `marcstraube/foundryvtt-scenery` | Nein      | Nein   |
+
+Diese Variable wird in `.gitlab-ci.yml` genutzt, damit Release-Artefakte auf
+GitHub als primäre Quelle verweisen.
+
+### CI/CD Settings
+
+- **Settings > CI/CD > General pipelines**
+  - Git strategy: `fetch` (schneller als `clone`)
+  - Timeout: 10 Minuten reicht
+
+- **Settings > CI/CD > Runners**
+  - Shared Runners sollten aktiviert sein (gitlab.com Standard)
+
+### Protected Tags
+
+- **Settings > Repository > Protected tags**
+  - Tag: `v*`
+  - Allowed to create: Maintainers (oder nur du)
+
+  Damit nur du Release-Tags pushen kannst und die Release-Pipeline auslöst.
+
+### Release erstellen
+
+Releases werden automatisch erstellt wenn ein Tag mit `v*.*.*` gepusht wird. Da
+GitLab ein Pull-Mirror ist, werden Tags automatisch von GitHub übernommen.
+
+Ablauf:
+
+1. Release auf GitHub erstellen (Tag `v1.0.0`)
+2. GitLab Mirror synchronisiert (max. 5 Min)
+3. GitLab CI erkennt den Tag und baut Release-Artefakte
+4. Artefakte enthalten GitHub-URLs in module.json
+
+### Optional: Merge Request Pipeline
+
+Die `.gitlab-ci.yml` Validate-Stage läuft automatisch bei Merge Requests. Bei
+einem reinen Mirror ohne MRs auf GitLab ist das irrelevant — schadet aber nicht.
+
+---
+
+## Checkliste vor Release
+
+- [ ] Alle Issues für Milestone geschlossen/verschoben
+- [ ] `update-v13` Branch in `master` gemerged
+- [ ] CI-Pipeline auf `master` grün
+- [ ] Release Draft auf GitHub prüfen (automatisch durch Release Drafter)
+- [ ] Release auf GitHub publishen mit Tag `v1.0.0`
+- [ ] Prüfen: module.zip enthält korrekte module.json mit Version + URLs
+- [ ] Prüfen: Foundry Installation via Manifest-URL funktioniert
+- [ ] GitLab Mirror synchronisiert und Release erstellt
+- [ ] Foundry Package Admin: neue Version einreichen (falls nötig)


### PR DESCRIPTION
Merge develop into master to complete the migration to trunk-based development.

After merging:
1. Set `master` as default branch
2. Transfer branch protection rules to `master`
3. Re-target open PRs to `master`
4. Delete `develop` branch
5. Update Weblate to point to `master`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fmarcstraube%2Ffoundryvtt-scenery%2Fpull%2F30&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->