### PR TITLE
ci: auto-merge dependabot patch/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    branches: [master]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-approve and merge patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add workflow to auto-approve and squash-merge dependabot PRs for patch/minor updates when CI passes
- Restrict dependabot group `dev-dependencies` to patch/minor — major updates get separate PRs for manual review
- Uses `dependabot/fetch-metadata` + actor check for security

## Test plan

- [ ] Verify workflow triggers on next dependabot PR
- [ ] Confirm major updates still create individual PRs
- [ ] Confirm patch/minor PRs get auto-merged after `validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)