### PR TITLE
chore: declare minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "prepare": "husky || true"
   },
   "packageManager": "pnpm@9.15.1",
+  "engines": {
+    "node": ">=22.22.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marcstraube/foundryvtt-scenery.git"


### PR DESCRIPTION
## Summary
- Adds `engines.node: ">=22.22.1"` to `package.json`
- Reflects the de-facto minimum already enforced by `lint-staged@17` (≥22.22.1) and `@commitlint/cli@21` (≥22)
- No code change — pure documentation of the runtime requirement

## Test plan
- [ ] CI passes (`validate` workflow)
- [ ] `pnpm install` still succeeds locally on Node ≥22.22.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)